### PR TITLE
Add Eleventy starter boilerplate into starter projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A scaffold for a quick start building with the Eleventy SSG.
 - [Eleventy Netlify Boilerplate](https://github.com/danurbanowicz/eleventy-netlify-boilerplate) - A boilerplate for building a simple website with the Eleventy static site generator.
 - [Eleventy Starter Ghost](https://github.com/TryGhost/eleventy-starter-ghost) - A starter template to build websites with Ghost & Eleventy.
 - [JAMStack Web Starter](https://github.com/scottishstoater/web-starter) - A modern static website workflow using Eleventy, Tailwind CSS, Webpack and PostCSS. 
+- [Eleventy Starter Boilerplate](https://creativedesignsguru.com/demo/Eleventy-Starter-Boilerplate/eleventy-starter-boilerplate-presentation/) - 🚀 Eleventy Starter Boilerplate is production-ready with SEO-friendly for quickly starting a blog. ⚡️ Built with Eleventy, ESLint, Prettier, Webpack, PostCSS, Tailwind CSS.
 
 
 ## Tutorials and guides


### PR DESCRIPTION
Little disclaimer: I am the author of the starter project. Recently, I have done a migration of my blog to Eleventy. So, I made a starter project and I think it could be great if I also share the code with other developers